### PR TITLE
Add support for Content Tweaker

### DIFF
--- a/src/main/java/lakmoore/infinitic/CommonProxy.java
+++ b/src/main/java/lakmoore/infinitic/CommonProxy.java
@@ -58,7 +58,6 @@ public class CommonProxy {
 		    if (material.isValid())
 		    {
 			    	material.getSolids();
-			    	material.addToOreDict();
 			    	material.makeMaterial();
 	    			material.makeFluid();	    			
 		    		material.integrateMaterial();
@@ -72,6 +71,7 @@ public class CommonProxy {
 		for (MaterialData material : InfiniTiC.MATERIALS) {
 		    if (material.isValid())
 		    {
+				material.addToOreDict();
 		    		material.addMaterialTraits();
 
 				if (material.json.hasGems() && material.fluid != null) {


### PR DESCRIPTION
This PR fixes #23
It allows Content Tweaker to be used with InfiniTiC by moving ore dict registration to the init phase where Content Tweaker items and blocks do exist.

Note: More things might need to be moved to init perhaps. This just works for the scripts that we needed.